### PR TITLE
🤔  Change API for `setStreams`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-flyd-component",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Live-Updating Stateless React Components Using Flyd",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
I realized that this was a bit confusing - separating the concern of
adding to the existing streams and setting a new stream makes things
more clear.  Using 'clearStreams' with an argument to set new streams
felt totally backwards.
